### PR TITLE
Fix IPO screener config import

### DIFF
--- a/screeners/ipo_investment/screener.py
+++ b/screeners/ipo_investment/screener.py
@@ -14,8 +14,7 @@ import sys
 from .data_manager import DataManager
 
 from config import (
-    IPO_INVESTMENT_RESULTS_DIR, 
-    IPO_INVESTMENT_CONFIG
+    IPO_INVESTMENT_RESULTS_DIR
 )
 from .indicators import (
     calculate_base_pattern,
@@ -23,9 +22,6 @@ from .indicators import (
     calculate_stochastic,
     calculate_track2_indicators
 )
-
-# 결과 저장 디렉토리
-IPO_INVESTMENT_RESULTS_DIR = os.path.join(RESULTS_DIR, 'ipo_investment')
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary
- remove local assignment to `IPO_INVESTMENT_RESULTS_DIR`
- clean up import list for IPO screener

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Markminervini')*

------
https://chatgpt.com/codex/tasks/task_e_6854e3a4f3c48328ac3fe9b321128b19