### PR TITLE
Refactor duplicate fetch functions into shared util

### DIFF
--- a/screeners/us_gainer/screener.py
+++ b/screeners/us_gainer/screener.py
@@ -8,35 +8,13 @@ import os
 from typing import List, Dict
 
 import pandas as pd
-import yfinance as yf
 
 from config import DATA_US_DIR, US_GAINER_RESULTS_DIR
-from utils import ensure_dir
+from utils import ensure_dir, fetch_market_cap, fetch_quarterly_eps_growth
 
 US_GAINERS_RESULTS_PATH = os.path.join(US_GAINER_RESULTS_DIR, 'us_gainers_results.csv')
 
 
-def _fetch_market_cap(symbol: str) -> int:
-    try:
-        info = yf.Ticker(symbol).info
-        return int(info.get('marketCap', 0) or 0)
-    except Exception:
-        return 0
-
-
-def _fetch_quarterly_eps_growth(symbol: str) -> float:
-    try:
-        ticker = yf.Ticker(symbol)
-        q_earnings = ticker.quarterly_earnings
-        if q_earnings is None or len(q_earnings) < 2:
-            return 0.0
-        recent_eps = q_earnings.iloc[-1]['Earnings']
-        prev_eps = q_earnings.iloc[-2]['Earnings']
-        if prev_eps == 0:
-            return 0.0
-        return (recent_eps - prev_eps) / abs(prev_eps) * 100
-    except Exception:
-        return 0.0
 
 
 def screen_us_gainers() -> pd.DataFrame:
@@ -70,11 +48,11 @@ def screen_us_gainers() -> pd.DataFrame:
         if rel_volume <= 2:
             continue
 
-        market_cap = _fetch_market_cap(symbol)
+        market_cap = fetch_market_cap(symbol)
         if market_cap < 1_000_000_000:
             continue
 
-        eps_growth = _fetch_quarterly_eps_growth(symbol)
+        eps_growth = fetch_quarterly_eps_growth(symbol)
         if eps_growth <= 10:
             continue
 

--- a/screeners/us_setup/screener.py
+++ b/screeners/us_setup/screener.py
@@ -9,10 +9,9 @@ import os
 from typing import List, Dict
 
 import pandas as pd
-import yfinance as yf
 
 from config import DATA_US_DIR, US_SETUP_RESULTS_DIR
-from utils import ensure_dir
+from utils import ensure_dir, fetch_market_cap
 
 US_SETUP_RESULTS_PATH = os.path.join(US_SETUP_RESULTS_DIR, 'us_setup_results.csv')
 
@@ -26,15 +25,6 @@ def _calculate_indicators(df: pd.DataFrame) -> pd.DataFrame:
     df['bb_std'] = df['close'].rolling(window=20).std()
     df['bb_upper'] = df['bb_mid'] + 2 * df['bb_std']
     return df
-
-
-def _fetch_market_cap(symbol: str) -> int:
-    try:
-        info = yf.Ticker(symbol).info
-        return int(info.get('marketCap', 0) or 0)
-    except Exception:
-        return 0
-
 
 def screen_us_setup() -> pd.DataFrame:
     results: List[Dict[str, float]] = []
@@ -67,7 +57,7 @@ def screen_us_setup() -> pd.DataFrame:
         if avg_volume60 <= 300_000:
             continue
 
-        market_cap = _fetch_market_cap(symbol)
+        market_cap = fetch_market_cap(symbol)
         if market_cap < 500_000_000:
             continue
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -28,6 +28,10 @@ from .relative_strength import (
     calculate_rs_score_enhanced,
     calculate_rs_score,
 )
+from .yfinance_helpers import (
+    fetch_market_cap,
+    fetch_quarterly_eps_growth,
+)
 
 __all__ = [
     'ensure_dir',
@@ -53,5 +57,7 @@ __all__ = [
     'get_investment_strategy',
     'calculate_rs_score_enhanced',
     'calculate_rs_score',
+    'fetch_market_cap',
+    'fetch_quarterly_eps_growth',
 ]
 

--- a/utils/yfinance_helpers.py
+++ b/utils/yfinance_helpers.py
@@ -1,0 +1,32 @@
+"""Helper functions wrapping yfinance to avoid duplication."""
+
+from __future__ import annotations
+
+import yfinance as yf
+
+__all__ = ["fetch_market_cap", "fetch_quarterly_eps_growth"]
+
+
+def fetch_market_cap(symbol: str) -> int:
+    """Return market cap of symbol in USD, 0 if unavailable."""
+    try:
+        info = yf.Ticker(symbol).info
+        return int(info.get("marketCap", 0) or 0)
+    except Exception:
+        return 0
+
+
+def fetch_quarterly_eps_growth(symbol: str) -> float:
+    """Return quarter-over-quarter EPS growth percent."""
+    try:
+        ticker = yf.Ticker(symbol)
+        q_earnings = ticker.quarterly_earnings
+        if q_earnings is None or len(q_earnings) < 2:
+            return 0.0
+        recent_eps = q_earnings.iloc[-1]["Earnings"]
+        prev_eps = q_earnings.iloc[-2]["Earnings"]
+        if prev_eps == 0:
+            return 0.0
+        return (recent_eps - prev_eps) / abs(prev_eps) * 100
+    except Exception:
+        return 0.0


### PR DESCRIPTION
## Summary
- create `utils/yfinance_helpers` for common yfinance helpers
- expose the new helpers via `utils` package
- use new helpers in `us_gainer` and `us_setup` screeners

## Testing
- `python -m py_compile screeners/us_gainer/screener.py screeners/us_setup/screener.py utils/yfinance_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_6854ea5ab7648328874abebe65f2b90d