### PR TITLE
Refactor duplicate utility functions

### DIFF
--- a/orchestrator/tasks.py
+++ b/orchestrator/tasks.py
@@ -17,7 +17,7 @@ except ImportError:  # pragma: no cover - optional dependency
 from portfolio.manager import create_portfolio_manager
 
 from data_collector import collect_data
-from utils import ensure_dir
+from utils import ensure_dir, create_required_dirs
 from utils.market_regime_indicator import analyze_market_regime
 from screeners.markminervini.filter_stock import run_integrated_screening
 from screeners.markminervini.advanced_financial import run_advanced_financial_screening
@@ -183,19 +183,22 @@ def check_strategy_file_status() -> List[str]:
 
 def ensure_directories() -> None:
     """Create required directories for the application."""
-    directories = [
-        RESULTS_DIR,
+    # 기본 디렉터리 생성
+    create_required_dirs()
+
+    # 추가 디렉터리 목록
+    additional = [
         SCREENER_RESULTS_DIR,
         PORTFOLIO_BUY_DIR,
         PORTFOLIO_SELL_DIR,
-        DATA_US_DIR,
         OPTION_VOLATILITY_DIR,
         MARKET_REGIME_DIR,
         os.path.join(RESULTS_DIR, "leader_stock"),
         os.path.join(RESULTS_DIR, "momentum_signals"),
         os.path.join(RESULTS_DIR, "ipo_investment"),
     ]
-    for directory in directories:
+
+    for directory in additional:
         ensure_dir(directory)
 
 

--- a/screeners/ipo_investment/indicators.py
+++ b/screeners/ipo_investment/indicators.py
@@ -1,6 +1,7 @@
 """Indicator utilities for IPOInvestmentScreener."""
 import pandas as pd
 from utils.calc_utils import calculate_rsi, calculate_atr
+from utils.technical_indicators import calculate_macd, calculate_stochastic
 
 __all__ = [
     "calculate_base_pattern",
@@ -28,20 +29,6 @@ def calculate_base_pattern(df: pd.DataFrame) -> pd.DataFrame:
     df['rolling_high'] = df['high'].rolling(window=20).max()
     df['rolling_low'] = df['low'].rolling(window=20).min()
     df['price_range'] = (df['rolling_high'] / df['rolling_low'] - 1) * 100
-    return df
-
-def calculate_macd(df: pd.DataFrame, fast: int = 12, slow: int = 26, signal: int = 9) -> pd.DataFrame:
-    df['ema_fast'] = df['close'].ewm(span=fast, adjust=False).mean()
-    df['ema_slow'] = df['close'].ewm(span=slow, adjust=False).mean()
-    df['macd'] = df['ema_fast'] - df['ema_slow']
-    df['macd_signal'] = df['macd'].ewm(span=signal, adjust=False).mean()
-    return df
-
-def calculate_stochastic(df: pd.DataFrame, k_period: int = 14, d_period: int = 3) -> pd.DataFrame:
-    df['lowest_low'] = df['low'].rolling(window=k_period).min()
-    df['highest_high'] = df['high'].rolling(window=k_period).max()
-    df['stoch_k'] = ((df['close'] - df['lowest_low']) / (df['highest_high'] - df['lowest_low'])) * 100
-    df['stoch_d'] = df['stoch_k'].rolling(window=d_period).mean()
     return df
 
 def calculate_track2_indicators(df: pd.DataFrame) -> pd.DataFrame:

--- a/screeners/ipo_investment/screener.py
+++ b/screeners/ipo_investment/screener.py
@@ -31,20 +31,7 @@ from utils.market_utils import (
 
 # 결과 저장 디렉토리는 config에서 제공됨
 
-# 섹터 ETF 매핑 (relative strength 계산용)
-SECTOR_ETFS = {
-    'Technology': 'XLK',
-    'Healthcare': 'XLV',
-    'Consumer Discretionary': 'XLY',
-    'Financials': 'XLF',
-    'Communication Services': 'XLC',
-    'Industrials': 'XLI',
-    'Consumer Staples': 'XLP',
-    'Energy': 'XLE',
-    'Utilities': 'XLU',
-    'Real Estate': 'XLRE',
-    'Materials': 'XLB',
-}
+
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/screeners/momentum_signals/indicators.py
+++ b/screeners/momentum_signals/indicators.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pandas as pd
 from scipy.signal import find_peaks
+from utils.technical_indicators import calculate_macd, calculate_stochastic
 
 __all__ = [
-    "calculate_macd",
-    "calculate_stochastic",
+"calculate_macd",
+"calculate_stochastic",
     "calculate_adx",
     "calculate_bollinger_bands",
     "calculate_moving_averages",
@@ -14,24 +15,6 @@ __all__ = [
     "calculate_ad",
     "detect_cup_and_handle",
 ]
-
-
-def calculate_macd(df: pd.DataFrame, fast: int = 12, slow: int = 26, signal: int = 9) -> pd.DataFrame:
-    df['ema_fast'] = df['close'].ewm(span=fast, adjust=False).mean()
-    df['ema_slow'] = df['close'].ewm(span=slow, adjust=False).mean()
-    df['macd'] = df['ema_fast'] - df['ema_slow']
-    df['macd_signal'] = df['macd'].ewm(span=signal, adjust=False).mean()
-    df['macd_hist'] = df['macd'] - df['macd_signal']
-    return df
-
-
-def calculate_stochastic(df: pd.DataFrame, k_period: int = 14, d_period: int = 3) -> pd.DataFrame:
-    df['lowest_low'] = df['low'].rolling(window=k_period).min()
-    df['highest_high'] = df['high'].rolling(window=k_period).max()
-    df['stoch_k'] = ((df['close'] - df['lowest_low']) / (df['highest_high'] - df['lowest_low'])) * 100
-    df['stoch_d'] = df['stoch_k'].rolling(window=d_period).mean()
-    return df
-
 
 def calculate_adx(df: pd.DataFrame, period: int = 14) -> pd.DataFrame:
     df['tr1'] = abs(df['high'] - df['low'])

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -32,6 +32,10 @@ from .yfinance_helpers import (
     fetch_market_cap,
     fetch_quarterly_eps_growth,
 )
+from .technical_indicators import (
+    calculate_macd,
+    calculate_stochastic,
+)
 
 __all__ = [
     'ensure_dir',
@@ -59,5 +63,7 @@ __all__ = [
     'calculate_rs_score',
     'fetch_market_cap',
     'fetch_quarterly_eps_growth',
+    'calculate_macd',
+    'calculate_stochastic',
 ]
 

--- a/utils/technical_indicators.py
+++ b/utils/technical_indicators.py
@@ -1,0 +1,40 @@
+"""Common technical indicator calculations used across screeners."""
+
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+
+__all__ = ["calculate_macd", "calculate_stochastic"]
+
+
+def calculate_macd(
+    df: pd.DataFrame,
+    fast: int = 12,
+    slow: int = 26,
+    signal: int = 9,
+    include_hist: bool = False,
+) -> pd.DataFrame:
+    """Calculate MACD indicators and optionally histogram."""
+    df["ema_fast"] = df["close"].ewm(span=fast, adjust=False).mean()
+    df["ema_slow"] = df["close"].ewm(span=slow, adjust=False).mean()
+    df["macd"] = df["ema_fast"] - df["ema_slow"]
+    df["macd_signal"] = df["macd"].ewm(span=signal, adjust=False).mean()
+    if include_hist:
+        df["macd_hist"] = df["macd"] - df["macd_signal"]
+    return df
+
+
+def calculate_stochastic(
+    df: pd.DataFrame,
+    k_period: int = 14,
+    d_period: int = 3,
+) -> pd.DataFrame:
+    """Calculate stochastic oscillator."""
+    df["lowest_low"] = df["low"].rolling(window=k_period).min()
+    df["highest_high"] = df["high"].rolling(window=k_period).max()
+    df["stoch_k"] = (
+        (df["close"] - df["lowest_low"]) / (df["highest_high"] - df["lowest_low"])
+    ) * 100
+    df["stoch_d"] = df["stoch_k"].rolling(window=d_period).mean()
+    return df


### PR DESCRIPTION
## Summary
- centralize MACD and stochastic calculations in `utils.technical_indicators`
- use new module in IPO and momentum screener indicator helpers
- remove sector ETF duplication in IPO screener
- reuse `create_required_dirs` in orchestrator setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854f4eb45d8832897ee85755f883903