### PR TITLE
Connect market breadth collector and fix IPO screener

### DIFF
--- a/orchestrator/tasks.py
+++ b/orchestrator/tasks.py
@@ -19,6 +19,7 @@ from portfolio.manager import create_portfolio_manager
 
 from data_collector import collect_data
 from utils import ensure_dir, create_required_dirs
+from data_collectors.market_breadth_collector import MarketBreadthCollector
 from utils.market_regime_indicator import analyze_market_regime
 from screeners.markminervini.filter_stock import run_integrated_screening
 from screeners.markminervini.advanced_financial import run_advanced_financial_screening
@@ -62,6 +63,7 @@ __all__ = [
     "run_leader_stock_screener",
     "run_momentum_signals_screener",
     "run_ipo_investment_screener",
+    "run_market_breadth_collection",
     "run_qullamaggie_strategy_task",
     "run_market_regime_analysis",
     "load_strategy_module",
@@ -226,6 +228,7 @@ def collect_data_main() -> None:
     print("\n💾 데이터 수집 시작...")
     try:
         collect_data()
+        run_market_breadth_collection()
         print("✅ 데이터 수집 완료")
     except Exception as e:  # pragma: no cover - runtime log
         print(f"❌ 데이터 수집 중 오류 발생: {e}")
@@ -354,6 +357,18 @@ def run_momentum_signals_screener() -> None:
             print("⚠️ 조건을 만족하는 종목이 없습니다.")
     except Exception as e:  # pragma: no cover - runtime log
         print(f"❌ 상승 모멘텀 신호 스크리너 실행 중 오류 발생: {e}")
+        print(traceback.format_exc())
+
+
+def run_market_breadth_collection(days: int = 252) -> None:
+    """Collect market breadth indicators."""
+    try:
+        print("\n📊 시장 폭 데이터 수집 시작...")
+        collector = MarketBreadthCollector()
+        collector.collect_all_data(days)
+        print("✅ 시장 폭 데이터 수집 완료")
+    except Exception as e:  # pragma: no cover - runtime log
+        print(f"❌ 시장 폭 데이터 수집 실패: {e}")
         print(traceback.format_exc())
 
 

--- a/screeners/ipo_investment/ipo_data_collector.py
+++ b/screeners/ipo_investment/ipo_data_collector.py
@@ -85,6 +85,10 @@ class IPODataCollector:
                     seen_symbols.add(ipo['symbol'])
                     unique_ipos.append(ipo)
             
+            if not unique_ipos:
+                logger.warning("실제 IPO 데이터 수집 결과가 비어있음. 기본 데이터 사용")
+                return self._get_fallback_ipo_data()
+
             logger.info(f"실제 IPO 데이터 수집 완료: {len(unique_ipos)}개 종목")
             return unique_ipos
             

--- a/screeners/ipo_investment/screener.py
+++ b/screeners/ipo_investment/screener.py
@@ -83,7 +83,7 @@ class IPOInvestmentScreener:
         if self.ipo_data.empty:
             return pd.DataFrame()
 
-        cutoff_date = self.today - timedelta(days=days)
+        cutoff_date = pd.Timestamp(self.today - timedelta(days=days))
         recent = self.ipo_data[self.ipo_data['ipo_date'] >= cutoff_date].copy()
         if recent.empty:
             return pd.DataFrame()


### PR DESCRIPTION
## Summary
- integrate MarketBreadthCollector into orchestrator tasks
- call breadth collection during data collection
- fallback to sample IPO data when online fetch fails
- fix date comparison error in IPO screener

## Testing
- `python -m py_compile orchestrator/tasks.py`
- `python -m py_compile screeners/ipo_investment/ipo_data_collector.py`
- `python -m py_compile screeners/ipo_investment/screener.py`
- `python -m py_compile data_collectors/market_breadth_collector.py`
- `python -m py_compile screeners/ipo_investment/data_manager.py`
- `python -m py_compile screeners/ipo_investment/institutional_data_collector.py`


------
https://chatgpt.com/codex/tasks/task_e_68556913b95c8328bdbe54adf68d40e5