### PR TITLE
Remove __main__ blocks from modules

### DIFF
--- a/portfolio/long_short/strategy1.py
+++ b/portfolio/long_short/strategy1.py
@@ -179,14 +179,6 @@ def run_strategy1_screening(total_capital=100000, update_existing=False):
 
 
 # 메인 실행 부분
-if __name__ == "__main__":
-    # 필요한 디렉토리 생성
-    ensure_dir(RESULTS_VER2_DIR)
-    ensure_dir(os.path.join(RESULTS_VER2_DIR, 'results')) # 통합 results 디렉토리
-    
-    print("\n📊 전략 1 스크리닝을 실행합니다. (결과 파일 생성)")
-    run_strategy(total_capital=100000, update_existing=False) 
-    print("\n💡 개별 포트폴리오 관리는 portfolio_managing 모듈을 사용하세요.")
 
 
 def run_strategy(total_capital=100000):

--- a/portfolio/long_short/strategy2.py
+++ b/portfolio/long_short/strategy2.py
@@ -200,14 +200,6 @@ def run_strategy2_screening(total_capital=100000, update_existing=False):
 
 
 # 메인 실행 부분
-if __name__ == "__main__":
-    # 필요한 디렉토리 생성
-    ensure_dir(RESULTS_VER2_DIR)
-    ensure_dir(os.path.join(RESULTS_VER2_DIR, 'results')) # 통합 results 디렉토리
-
-    print("\n📊 전략 2 스크리닝을 실행합니다. (결과 파일 생성)")
-    run_strategy(total_capital=100000, update_existing=False)
-    print("\n💡 개별 포트폴리오 관리는 portfolio_managing 모듈을 사용하세요.")
 
 def run_strategy(total_capital=100000):
     """Wrapper function for main.py compatibility"""

--- a/portfolio/long_short/strategy3.py
+++ b/portfolio/long_short/strategy3.py
@@ -165,9 +165,3 @@ def run_strategy(total_capital=100000):
     """Wrapper function for main.py compatibility"""
     return run_strategy3_screening(total_capital=total_capital, update_existing=False)
 
-if __name__ == "__main__":
-    ensure_dir(RESULTS_VER2_DIR)
-    ensure_dir(os.path.join(RESULTS_VER2_DIR, 'results')) # 통합 results 디렉토리
-    
-    print("\n📊 전략 3 스크리닝을 실행합니다. 개별 포트폴리오 관리는 portfolio_managing 모듈을 이용해주세요.")
-    run_strategy()

--- a/portfolio/long_short/strategy4.py
+++ b/portfolio/long_short/strategy4.py
@@ -169,8 +169,3 @@ def run_strategy(total_capital=100000):
     """Wrapper function for main.py compatibility"""
     return run_strategy4_screening()
 
-if __name__ == "__main__":
-    ensure_dir(RESULTS_VER2_DIR) # RESULTS_DIR 대신 RESULTS_VER2_DIR 사용
-    ensure_dir(os.path.join(RESULTS_VER2_DIR, 'results')) # 통합 results 디렉토리
-    print("\n📊 전략 4 스크리닝을 실행합니다. 개별 포트폴리오 관리는 portfolio_managing 모듈을 이용해주세요.")
-    run_strategy()

--- a/portfolio/long_short/strategy5.py
+++ b/portfolio/long_short/strategy5.py
@@ -172,7 +172,3 @@ def run_strategy(total_capital=100000):
     """Wrapper function for main.py compatibility"""
     return run_strategy5_screening()
 
-if __name__ == "__main__":
-    ensure_dir(RESULTS_VER2_DIR)
-    ensure_dir(os.path.join(RESULTS_VER2_DIR, 'results'))
-    print("\n📊 전략 5 스크리닝을 실행합니다. 개별 포트폴리오 관리는 portfolio_managing 모듈을 이용해주세요.")

--- a/portfolio/long_short/strategy6.py
+++ b/portfolio/long_short/strategy6.py
@@ -167,22 +167,6 @@ def run_strategy6_screening():
 
 
 
-if __name__ == '__main__':
-    # 결과 디렉토리 생성
-    ensure_dir(RESULTS_VER2_DIR) # RESULTS_DIR 대신 RESULTS_VER2_DIR 사용
-    ensure_dir(os.path.join(RESULTS_VER2_DIR, 'results')) # 통합 results 디렉토리
-
-    # 총 자산 설정
-    CAPITAL = 100000
-
-    print("🚀 전략 6 스크리닝을 실행합니다. 개별 포트폴리오 관리는 portfolio_managing 모듈을 이용해주세요.")
-    try:
-        run_strategy(total_capital=CAPITAL)
-    except Exception as e:
-        print(f"❌ 전략 6 실행 중 오류 발생: {e}")
-        print(traceback.format_exc())
-
-    print("\n🎉 전략 6 실행 완료.")
 
 
 def run_strategy(total_capital=100000):

--- a/portfolio/manager/strategies/volatility_skew_strategy.py
+++ b/portfolio/manager/strategies/volatility_skew_strategy.py
@@ -141,16 +141,3 @@ def run_volatility_skew_portfolio_strategy(alpha_vantage_key: Optional[str] = No
     strategy = VolatilitySkewPortfolioStrategy(alpha_vantage_key=alpha_vantage_key)
     return strategy.run_screening_and_portfolio_creation()
 
-
-if __name__ == "__main__":
-    # 테스트 실행
-    print("🚀 변동성 스큐 포트폴리오 전략 테스트")
-    
-    strategy = VolatilitySkewPortfolioStrategy()
-    signals, file_path = strategy.run_screening_and_portfolio_creation()
-    
-    if signals:
-        print(f"\n✅ 포트폴리오 신호 생성 완료: {len(signals)}개")
-        print(f"📁 파일: {file_path}")
-    else:
-        print("\n❌ 포트폴리오 신호 생성 실패")

--- a/screeners/ipo_investment/data_manager.py
+++ b/screeners/ipo_investment/data_manager.py
@@ -256,13 +256,6 @@ class DataManager:
         return status
 
 # 사용 예시
-if __name__ == "__main__":
-    manager = DataManager()
-    
-    # 데이터 상태 확인
-    status = manager.get_data_status()
-    print("데이터 소스 상태:")
-    print(json.dumps(status, indent=2, ensure_ascii=False))
     
     # IPO 데이터 가져오기
     ipo_data = manager.get_ipo_data()

--- a/screeners/ipo_investment/institutional_data_collector.py
+++ b/screeners/ipo_investment/institutional_data_collector.py
@@ -198,14 +198,6 @@ class InstitutionalDataCollector:
             return pd.DataFrame()
 
 # 사용 예시
-if __name__ == "__main__":
-    collector = InstitutionalDataCollector()
-    
-    # 기관 보유 현황 조회
-    symbol = "AAPL"
-    holdings = collector.get_institutional_holdings(symbol)
-    print(f"{symbol} 기관 보유 현황:")
-    print(holdings)
     
     # 기관 자금 흐름 분석
     flow_analysis = collector.get_institutional_flow(symbol, 30)

--- a/screeners/ipo_investment/ipo_data_collector.py
+++ b/screeners/ipo_investment/ipo_data_collector.py
@@ -341,6 +341,3 @@ def main():
     except Exception as e:
         logger.error(f"IPO 데이터 수집 중 오류 발생: {e}")
         raise
-
-if __name__ == "__main__":
-    main()

--- a/screeners/ipo_investment/screener.py
+++ b/screeners/ipo_investment/screener.py
@@ -458,5 +458,3 @@ def run_ipo_investment_screening():
     return screener.screen_ipo_investments()
 
 
-if __name__ == "__main__":
-    run_ipo_investment_screening()

--- a/screeners/leader_stock/screener.py
+++ b/screeners/leader_stock/screener.py
@@ -357,6 +357,4 @@ def run_leader_stock_screening():
     return screener.screen_leader_stocks()
 
 
-if __name__ == "__main__":
-    run_leader_stock_screening()
 

--- a/screeners/markminervini/advanced_financial.py
+++ b/screeners/markminervini/advanced_financial.py
@@ -151,5 +151,3 @@ def run_advanced_financial_screening(force_update=False):
         traceback.print_exc()
 
 # 직접 실행 시
-if __name__ == "__main__":
-    run_advanced_financial_screening()

--- a/screeners/markminervini/filter_stock.py
+++ b/screeners/markminervini/filter_stock.py
@@ -140,6 +140,3 @@ def main():
     
     # 기본적으로 US 주식 데이터 처리
     filter_us()
-
-if __name__ == '__main__':
-    main()

--- a/screeners/markminervini/screener.py
+++ b/screeners/markminervini/screener.py
@@ -419,21 +419,3 @@ def setup_scheduler(collect_hour=1, screen_hour=2):
     while True:
         schedule.run_pending()
         time.sleep(60)
-
-# 명령행 인터페이스
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Mark Minervini 스크리너 - 스크리닝")
-    parser.add_argument("--collect", action="store_true", help="데이터 수집 후 스크리닝 실행")
-    parser.add_argument("--schedule", action="store_true", help="스케줄러 설정 및 실행")
-    parser.add_argument("--collect-hour", type=int, default=1, help="데이터 수집 시간 (24시간제)")
-    parser.add_argument("--screen-hour", type=int, default=2, help="스크리닝 시간 (24시간제)")
-    
-    args = parser.parse_args()
-    
-    if args.schedule:
-        setup_scheduler(args.collect_hour, args.screen_hour)
-    elif args.collect:
-        collect_data()
-        run_screening()
-    else:
-        run_screening()

--- a/screeners/markminervini/ticker_tracker.py
+++ b/screeners/markminervini/ticker_tracker.py
@@ -174,8 +174,3 @@ def track_new_tickers(advanced_financial_results_path):
         print(f"현재 추적 중인 티커 수: {len(new_tickers_df)}")
     except Exception as e:
         print(f"오류: 새로 추가된 티커 정보를 저장하는 중 오류가 발생했습니다: {e}")
-
-if __name__ == "__main__":
-    from config import ADVANCED_FINANCIAL_RESULTS_PATH
-    track_new_tickers(ADVANCED_FINANCIAL_RESULTS_PATH)
-    print("\n실행이 완료되었습니다. 터미널에서 실행하려면 'py ticker_tracker.py' 명령어를 사용하세요.")

--- a/screeners/momentum_signals/screener.py
+++ b/screeners/momentum_signals/screener.py
@@ -353,5 +353,3 @@ def run_momentum_signals_screening():
     return screener.screen_momentum_signals()
 
 
-if __name__ == "__main__":
-    run_momentum_signals_screening()

--- a/screeners/option_volatility/volatility_skew_screener.py
+++ b/screeners/option_volatility/volatility_skew_screener.py
@@ -438,21 +438,3 @@ def run_volatility_skew_screening(alpha_vantage_key: Optional[str] = None) -> Tu
     """변동성 스큐 스크리닝 실행 함수 (main.py에서 호출용)"""
     screener = VolatilitySkewScreener(alpha_vantage_key=alpha_vantage_key)
     return screener.run_screening()
-
-
-if __name__ == "__main__":
-    # 직접 실행 시 테스트
-    print("🚀 변동성 스큐 역전 전략 테스트 실행")
-    
-    # Alpha Vantage API 키가 있다면 여기에 입력
-    API_KEY = None  # "YOUR_ALPHA_VANTAGE_KEY"
-    
-    screener = VolatilitySkewScreener(alpha_vantage_key=API_KEY)
-    portfolios, signals, portfolio_file, signals_file = screener.run_screening()
-    
-    if portfolios:
-        print(f"\n✅ 포트폴리오 구성 완료")
-        print(f"📁 포트폴리오 파일: {portfolio_file}")
-        print(f"📁 신호 파일: {signals_file}")
-    else:
-        print("\n❌ 포트폴리오 구성에 실패했습니다.")

--- a/screeners/qullamaggie/screener.py
+++ b/screeners/qullamaggie/screener.py
@@ -144,5 +144,3 @@ def main():
     # 스크리닝 실행
     run_qullamaggie_screening(args.setup)
 
-if __name__ == '__main__':
-    main()

--- a/screeners/qullamaggie/signal_generator.py
+++ b/screeners/qullamaggie/signal_generator.py
@@ -386,6 +386,3 @@ def main():
             generate_sell_signals()
         if args.manage:
             manage_positions()
-
-if __name__ == '__main__':
-    main()

--- a/screeners/us_gainer/screener.py
+++ b/screeners/us_gainer/screener.py
@@ -103,5 +103,3 @@ def screen_us_gainers() -> pd.DataFrame:
     return pd.DataFrame()
 
 
-if __name__ == '__main__':
-    screen_us_gainers()

--- a/screeners/us_setup/screener.py
+++ b/screeners/us_setup/screener.py
@@ -118,5 +118,3 @@ def screen_us_setup() -> pd.DataFrame:
         return pd.DataFrame()
 
 
-if __name__ == '__main__':
-    screen_us_setup()


### PR DESCRIPTION
## Summary
- remove `__main__` entrypoints from screeners
- remove `__main__` entrypoints from portfolio strategies
- keep reusable run functions only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685597eca2c48328a36433ad159f04a3