### PR TITLE
Add metadata collector integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ python api_server.py
 # GET http://localhost:5000/api/strategy-results
 
 ```
+### 주식 메타데이터 수집
+`leader_stock`과 `momentum_signals` 스크리너는 섹터, PER, 매출 성장률 등
+기본 메타데이터가 포함된 `data/stock_metadata.csv` 파일을 사용합니다.
+메인 프로그램에서 데이터 수집 시 자동으로 생성되며, 필요 시 다음
+명령으로 개별 실행할 수 있습니다.
+
+```bash
+python data_collectors/stock_metadata_collector.py
+```
+
+파일 경로는 `config.STOCK_METADATA_PATH` 설정을 따릅니다.
 ## 📊 스크리닝 기준
 ### 기술적 분석 (Mark Minervini 기법)
 - 현재가 > 150일/200일 이동평균

--- a/data_collectors/stock_metadata_collector.py
+++ b/data_collectors/stock_metadata_collector.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Collect sector and key financial metadata for US stocks.
+
+The output ``data/stock_metadata.csv`` contains the following columns:
+``symbol``, ``sector``, ``pe_ratio``, ``revenue_growth``, and ``market_cap``.
+Symbols are derived from existing OHLCV files under ``data/us``.
+"""
+
+import os
+import logging
+import time
+from typing import Dict, List
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pandas as pd
+import yfinance as yf
+
+from config import (
+    DATA_US_DIR,
+    STOCK_METADATA_PATH,
+    YAHOO_FINANCE_MAX_RETRIES,
+    YAHOO_FINANCE_DELAY,
+)
+from utils import ensure_dir
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def fetch_metadata(symbol: str,
+                   max_retries: int = YAHOO_FINANCE_MAX_RETRIES,
+                   delay: int = YAHOO_FINANCE_DELAY) -> Dict[str, object]:
+    """Return metadata for a given symbol using yfinance with retries."""
+    for attempt in range(max_retries):
+        try:
+            tkr = yf.Ticker(symbol)
+            info = tkr.info
+            sector = info.get("sector", "") or ""
+            pe = info.get("trailingPE") or info.get("forwardPE")
+            market_cap = info.get("marketCap")
+
+            revenue_growth = None
+            try:
+                fin = tkr.financials
+                if fin is not None and not fin.empty and "Total Revenue" in fin.index:
+                    revs = fin.loc["Total Revenue"].dropna()
+                    if len(revs) >= 2 and revs.iloc[1] != 0:
+                        revenue_growth = (revs.iloc[0] - revs.iloc[1]) / abs(revs.iloc[1]) * 100
+            except Exception:
+                revenue_growth = None
+
+            return {
+                "symbol": symbol,
+                "sector": sector,
+                "pe_ratio": pe,
+                "revenue_growth": revenue_growth,
+                "market_cap": market_cap,
+            }
+        except Exception as e:
+            logger.warning(f"{symbol} 메타데이터 수집 실패 (시도 {attempt + 1}/{max_retries}): {e}")
+            if attempt < max_retries - 1:
+                time.sleep(delay * (attempt + 1))
+
+    return {
+        "symbol": symbol,
+        "sector": "",
+        "pe_ratio": None,
+        "revenue_growth": None,
+        "market_cap": None,
+    }
+
+
+def collect_stock_metadata(symbols: List[str], max_workers: int = 5) -> pd.DataFrame:
+    """Collect metadata for a list of symbols concurrently."""
+    records: List[Dict[str, object]] = []
+    failures: List[str] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_symbol = {executor.submit(fetch_metadata, sym): sym for sym in symbols}
+        for future in as_completed(future_to_symbol):
+            sym = future_to_symbol[future]
+            try:
+                data = future.result()
+                if data["sector"] == "" and data["pe_ratio"] is None and data["market_cap"] is None:
+                    failures.append(sym)
+                records.append(data)
+            except Exception as e:  # pragma: no cover - unexpected
+                logger.error(f"{sym} 메타데이터 처리 오류: {e}")
+                failures.append(sym)
+    if failures:
+        logger.warning(f"메타데이터 수집 실패 종목 {len(failures)}개: {', '.join(failures)}")
+    return pd.DataFrame(records)
+
+
+def get_symbols() -> List[str]:
+    """Return list of tickers based on files under DATA_US_DIR."""
+    files = [f for f in os.listdir(DATA_US_DIR) if f.endswith(".csv")]
+    return [os.path.splitext(f)[0].split("_")[0] for f in files]
+
+
+def main() -> None:
+    ensure_dir(os.path.dirname(STOCK_METADATA_PATH))
+    symbols = get_symbols()
+    logger.info("메타데이터 수집 대상 종목 수: %d", len(symbols))
+    df = collect_stock_metadata(symbols)
+    df.to_csv(STOCK_METADATA_PATH, index=False)
+    logger.info("✅ 메타데이터 저장 완료: %s (%d tickers)", STOCK_METADATA_PATH, len(df))
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrator/tasks.py
+++ b/orchestrator/tasks.py
@@ -20,6 +20,7 @@ from portfolio.manager import create_portfolio_manager
 from data_collector import collect_data
 from utils import ensure_dir, create_required_dirs
 from data_collectors.market_breadth_collector import MarketBreadthCollector
+from data_collectors.stock_metadata_collector import main as collect_stock_metadata_main
 from utils.market_regime_indicator import analyze_market_regime
 from screeners.markminervini.filter_stock import run_integrated_screening
 from screeners.markminervini.advanced_financial import run_advanced_financial_screening
@@ -67,6 +68,7 @@ __all__ = [
     "run_ipo_investment_screener",
     "run_market_breadth_collection",
     "run_ipo_data_collection",
+    "run_stock_metadata_collection",
     "run_qullamaggie_strategy_task",
     "run_market_regime_analysis",
     "load_strategy_module",
@@ -235,6 +237,7 @@ def collect_data_main() -> None:
         run_market_breadth_collection()
         run_market_regime_analysis()
         run_ipo_data_collection()
+        run_stock_metadata_collection()
         print("✅ 데이터 수집 완료")
     except Exception as e:  # pragma: no cover - runtime log
         print(f"❌ 데이터 수집 중 오류 발생: {e}")
@@ -403,6 +406,17 @@ def run_ipo_data_collection(days: int = 365) -> None:
             print("⚠️ IPO 데이터 저장 실패 또는 데이터 없음")
     except Exception as e:  # pragma: no cover - runtime log
         print(f"❌ IPO 데이터 수집 중 오류 발생: {e}")
+        print(traceback.format_exc())
+
+
+def run_stock_metadata_collection() -> None:
+    """Collect and save stock metadata."""
+    try:
+        print("\n📊 주식 메타데이터 수집 시작...")
+        collect_stock_metadata_main()
+        print("✅ 주식 메타데이터 수집 완료")
+    except Exception as e:  # pragma: no cover - runtime log
+        print(f"❌ 주식 메타데이터 수집 실패: {e}")
         print(traceback.format_exc())
 
 

--- a/screeners/momentum_signals/screener.py
+++ b/screeners/momentum_signals/screener.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-"""상승 모멘텀 신호 (Uptrend Momentum Signals) 스크리너"""
+"""상승 모멘텀 신호 (Uptrend Momentum Signals) 스크리너.
+
+섹터 정보를 포함한 ``data/stock_metadata.csv`` 파일을 사용한다.
+파일 위치는 ``config.STOCK_METADATA_PATH`` 설정을 따른다.
+"""
 
 import os
 import pandas as pd


### PR DESCRIPTION
## Summary
- simplify metadata collector and remove IPO date
- call the collector in the main data collection routine
- note metadata file usage and auto-generation in README
- update screeners to use the modified metadata file
- add retry and concurrency to metadata collector

## Testing
- `python -m py_compile data_collectors/stock_metadata_collector.py`
- `python -m py_compile orchestrator/tasks.py`
- `python -m py_compile screeners/leader_stock/screener.py screeners/momentum_signals/screener.py`


------
https://chatgpt.com/codex/tasks/task_e_685597ee095c832895e50b7be8e602c6