### PR TITLE
Improve scheduler sequential timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ python main.py --task setup
 python main.py --task portfolio --skip-data
 ```
 
+### 스케줄러 사용
+```bash
+# `--skip-data` 스크리너가 끝날 때마다 1분 후 다시 실행하며,
+# 한국 시각 14:30 이후 첫 실행이 완료되면 1분 뒤에 전체 모드를 한 번 수행합니다.
+python main.py --schedule
+
+# 간단한 유지용 실행을 수동으로 하려면
+python main.py --task screening --skip-data
+```
+
 ### 포트폴리오 관리
 ```bash
 # 개별 전략 실행
@@ -84,6 +94,9 @@ python api_server.py
 # GET http://localhost:5000/api/strategy-results
 
 ```
+각 스크리너 API는 `last_updated` 필드로 데이터 파일의 수정 시간을 함께 반환하므로
+프론트엔드에서 최신 여부를 쉽게 확인할 수 있습니다. 이 시간은 각 스크리닝
+작업이 완료된 시각을 기준으로 합니다.
 ### 주식 메타데이터 수집
 `leader_stock`과 `momentum_signals` 스크리너는 섹터, PER, 매출 성장률 등
 기본 메타데이터가 포함된 `data/stock_metadata.csv` 파일을 사용합니다.

--- a/frontend/app/markminervini/[screenerId]/page.tsx
+++ b/frontend/app/markminervini/[screenerId]/page.tsx
@@ -35,6 +35,7 @@ export default function ScreenerPage({ params }: ScreenerPageProps) {
   const [sliderFilters, setSliderFilters] = useState<SliderFilter[]>([]);
   const [showFilters, setShowFilters] = useState(false);
   const [description, setDescription] = useState('');
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
 
   const getScreenerName = (id: string) => {
     const names: { [key: string]: string } = {
@@ -61,6 +62,7 @@ export default function ScreenerPage({ params }: ScreenerPageProps) {
             const dataArray = Array.isArray(result.data) ? result.data : [];
             setData(dataArray);
             initializeSliderFilters(dataArray);
+            setLastUpdated(result.last_updated || null);
             setError(null);
           } else {
             setError(result.error || 'Failed to fetch screener data');
@@ -334,6 +336,11 @@ export default function ScreenerPage({ params }: ScreenerPageProps) {
       
       {filteredData.length > 0 ? (
         <div className="bg-white rounded-lg shadow overflow-hidden">
+          {lastUpdated && (
+            <div className="text-right text-xs text-gray-400 pr-4 pt-2">
+              Last updated: {new Date(lastUpdated).toLocaleString()}
+            </div>
+          )}
           <DataTable
             data={filteredData}
             columns={columns}

--- a/frontend/app/markminervini/all/page.tsx
+++ b/frontend/app/markminervini/all/page.tsx
@@ -12,6 +12,7 @@ interface ScreenerData {
   name: string;
   data: ScreenerResult[];
   type: string;
+  lastUpdated?: string;
 }
 
 interface SliderFilter {
@@ -56,7 +57,8 @@ export default function AllMarkminerviniPage() {
                 results.push({
                   name: screener.name,
                   data: Array.isArray(result.data) ? result.data : [],
-                  type: screener.id
+                  type: screener.id,
+                  lastUpdated: result.last_updated || undefined
                 });
               } else {
                 console.warn(`API call for ${screener.id} was successful but data was not valid:`, result); // ADDED LOG
@@ -381,6 +383,11 @@ export default function AllMarkminerviniPage() {
                   }));
                   return filteredData.length > 0 ? (
                     <>
+                      {screenerData.lastUpdated && (
+                        <div className="text-right text-xs text-gray-400 pr-4 pt-2">
+                          Last updated: {new Date(screenerData.lastUpdated).toLocaleString()}
+                        </div>
+                      )}
                       <DataTable data={filteredData.slice(0, 10)} columns={columns} headerRowClassName="bg-gray-50" />
                       {filteredData.length > 10 && (
                         <div className="p-4 text-center text-gray-500 text-sm">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -5,6 +5,7 @@ export interface ApiResponse<T> {
   data?: T;
   message?: string;
   total_count?: number;
+  last_updated?: string;
 }
 
 export interface ScreeningData {

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ def main():
     parser.add_argument('--skip-data', action='store_true', help='데이터 수집 건너뛰기')
     parser.add_argument('--force-screening', action='store_true', help='강제 스크리닝 실행')
     parser.add_argument('--task', default='all',
-                        choices=['all', 'volatility-skew', 'setup', 'gainers', 'leader-stock',
+                        choices=['all', 'screening', 'volatility-skew', 'setup', 'gainers', 'leader-stock',
                                  'momentum', 'ipo', 'qullamaggie', 'portfolio', 'market-regime'],
                         help='실행할 작업 선택')
     parser.add_argument('--schedule', action='store_true', help='스케줄러 모드 실행')
@@ -77,6 +77,10 @@ def main():
         if task == 'leader-stock':
             print("\n🎯 주도주 전략 모드")
             run_leader_stock_screener()
+            return
+        if task == 'screening':
+            print("\n🎯 스크리닝 전용 모드")
+            run_all_screening_processes(skip_data=args.skip_data)
             return
         if task == 'momentum':
             print("\n🎯 상승 모멘텀 신호 모드")

--- a/orchestrator/tasks.py
+++ b/orchestrator/tasks.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import os
+import sys
 import time
 import traceback
 import pandas as pd
 import importlib.util
 from datetime import datetime
 from typing import List, Optional
-
-try:
-    import schedule
-except ImportError:  # pragma: no cover - optional dependency
-    schedule = None
 
 from portfolio.manager import create_portfolio_manager
 
@@ -73,6 +69,7 @@ __all__ = [
     "run_market_regime_analysis",
     "load_strategy_module",
     "run_after_market_close",
+    "run_keep_alive",
     "setup_scheduler",
     "run_scheduler",
 ]
@@ -244,8 +241,16 @@ def collect_data_main() -> None:
         print(traceback.format_exc())
 
 
-def run_all_screening_processes() -> None:
-    """Execute all screening steps sequentially."""
+def run_all_screening_processes(skip_data: bool = False) -> None:
+    """Execute all screening steps sequentially.
+
+    Parameters
+    ----------
+    skip_data : bool, optional
+        Currently unused flag that can be leveraged by scheduled keep alive
+        tasks to indicate that heavy data collection should be skipped, by
+        default False.
+    """
     print("\n⚙️ 스크리닝 프로세스 시작...")
     try:
         print("\n⏳ 1단계: 통합 스크리닝 실행 중...")
@@ -521,23 +526,59 @@ def run_after_market_close() -> None:
         print(f"❌ 자동 포트폴리오 업데이트 실패: {e}")
 
 
-def setup_scheduler() -> None:
-    """Configure daily scheduler at 16:30."""
-    if schedule is None:
-        raise ImportError("schedule 패키지가 설치되어 있지 않습니다.")
-    schedule.every().day.at("16:30").do(run_after_market_close)
-    print("📅 스케줄러 설정 완료: 매일 오후 4시 30분에 포트폴리오 업데이트 실행")
+def run_keep_alive() -> None:
+    """Run a lightweight screening cycle used for keep-alive schedules."""
+    run_all_screening_processes(skip_data=True)
+
+
+def _convert_kst_to_local(time_str: str) -> str:
+    """Convert HH:MM KST time string to local server time string."""
+    try:
+        import pytz
+    except Exception:
+        return time_str
+    kst = pytz.timezone("Asia/Seoul")
+    local_tz = datetime.now().astimezone().tzinfo
+    dt = datetime.strptime(time_str, "%H:%M")
+    kst_dt = kst.localize(dt)
+    local_dt = kst_dt.astimezone(local_tz)
+    return local_dt.strftime("%H:%M")
+
+
+_SCHED_CONF = {"full_time": "14:30", "interval": 1}
+
+
+def setup_scheduler(full_run_time: str = "14:30", keep_alive_interval: int = 1) -> None:
+    """Configure parameters for the keep-alive scheduler."""
+    _SCHED_CONF["full_time"] = full_run_time
+    _SCHED_CONF["interval"] = keep_alive_interval
+    print(
+        f"📅 스케줄러 설정: 매일 {full_run_time} KST 이후 첫 실행 시 전체 모드,"
+        f" {keep_alive_interval}분 간격 keep-alive"
+    )
 
 
 def run_scheduler() -> None:
-    """Run the configured scheduler."""
-    if schedule is None:
-        raise ImportError("schedule 패키지가 설치되어 있지 않습니다.")
-    setup_scheduler()
+    """Run the keep-alive loop with a daily full run after the set time."""
+    try:
+        import pytz
+    except Exception:  # pragma: no cover - timezone optional
+        pytz = None
+
+    full_time = datetime.strptime(_SCHED_CONF["full_time"], "%H:%M").time()
+    interval = _SCHED_CONF["interval"]
+    kst_tz = pytz.timezone("Asia/Seoul") if pytz else None
+    last_full_date = None
+
     print("🔄 스케줄러 시작... (Ctrl+C로 종료)")
     try:
         while True:
-            schedule.run_pending()
-            time.sleep(60)
+            run_keep_alive()
+            end = datetime.now(kst_tz)
+            if end.time() >= full_time and (last_full_date != end.date()):
+                time.sleep(interval * 60)
+                os.system(f"{sys.executable} main.py")
+                last_full_date = (datetime.now(kst_tz)).date() if kst_tz else datetime.now().date()
+            time.sleep(interval * 60)
     except KeyboardInterrupt:
         print("\n⏹️ 스케줄러 종료")


### PR DESCRIPTION
## Summary
- run keep-alive tasks using internal screening function
- wait one minute after each run before restarting the scheduler loop
- full run executes once after 14:30 KST, starting a minute after the last keep-alive run
- document the revised scheduling behaviour in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685654783d088328825f46e09753dc0d