### PR TITLE
Add patterndetection wrapper and fix skew grade bug

### DIFF
--- a/patterndetection.py
+++ b/patterndetection.py
@@ -1,0 +1,26 @@
+"""Academic pattern detection wrapper.
+
+This script uses advanced algorithms based on `new VCP & CUPhandle.md`
+for detecting Volatility Contraction and Cup & Handle patterns.
+It simply exposes a CLI around the existing implementation
+in `screeners.markminervini.pattern_detection` for backward compatibility.
+"""
+
+from screeners.markminervini.pattern_detection import (
+    run_pattern_detection_on_financial_results,
+)
+
+
+def main() -> None:
+    """Run pattern detection using academic rules."""
+    print("🔬 패턴 감지 시작...")
+    results = run_pattern_detection_on_financial_results()
+    if results is not None and not results.empty:
+        print(f"✅ 패턴 분석 완료: {len(results)}개 종목 감지")
+    else:
+        print("⚠️ 패턴을 만족하는 종목이 없습니다.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/screeners/markminervini/advanced_financial.py
+++ b/screeners/markminervini/advanced_financial.py
@@ -121,7 +121,7 @@ def run_advanced_financial_screening(force_update=False):
                     # 패턴 감지 실행
                     print("\n🔍 패턴 감지를 시작합니다...")
                     try:
-                        from pattern_detection import run_pattern_detection_on_financial_results
+                        from .pattern_detection import run_pattern_detection_on_financial_results
                         pattern_results = run_pattern_detection_on_financial_results()
                         if not pattern_results.empty:
                             print(f"✅ 패턴 감지 완료: {len(pattern_results)}개 종목")

--- a/screeners/option_volatility/volatility_skew_screener.py
+++ b/screeners/option_volatility/volatility_skew_screener.py
@@ -34,6 +34,7 @@ class VolatilitySkewScreener(SkewCalculationsMixin):
             "yfinance": {"grade": "B", "confidence_multiplier": 0.9, "description": "양호한 품질 무료 데이터"},
             "yfinance_fallback": {"grade": "C", "confidence_multiplier": 0.7, "description": "품질 부족하지만 사용 가능한 데이터"}
         }
+        self.grade_description_map = {info["grade"]: info["description"] for info in self.data_quality_grades.values()}
 
     def get_large_cap_stocks(self) -> List[str]:
         """S&P 500 전체 종목 가져오기"""
@@ -318,7 +319,7 @@ class VolatilitySkewScreener(SkewCalculationsMixin):
         for grade in ['A', 'B', 'C']:
             count = quality_counts.get(grade, 0)
             if count > 0:
-                description = list(self.data_quality_grades.values())[ord(grade) - ord('A')]['description']
+                description = self.grade_description_map.get(grade, "")
                 report.append(f"• {grade}등급: {count}개 종목 ({description})")
         
         # 품질 경고


### PR DESCRIPTION
## Summary
- add new `patterndetection.py` CLI wrapper referencing advanced detection logic
- fix import path in `advanced_financial.py`
- prevent list out-of-range when describing skew data grades

## Testing
- `python -m py_compile screeners/markminervini/advanced_financial.py screeners/option_volatility/volatility_skew_screener.py patterndetection.py`

------
https://chatgpt.com/codex/tasks/task_e_68570082c24483288a7335a784c628ee